### PR TITLE
replace utcnow() by now(datetime.timezone.utc)

### DIFF
--- a/smart4-vdsl
+++ b/smart4-vdsl
@@ -130,7 +130,7 @@ def get_formatted_output(status, format):
         return ''
 
 def get_current_utc_time():
-    return datetime.datetime.utcnow().replace(microsecond=0).isoformat()
+    return datetime.datetime.now(datetime.timezone.utc).replace(microsecond=0).isoformat()
 
 def eprint(*args, **kwargs):
     print(*args, file=sys.stderr, **kwargs)


### PR DESCRIPTION
datetime.utcnow() is deprecated since 3.12